### PR TITLE
Additions to generic editor functionality

### DIFF
--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -55,7 +55,6 @@ select line:
 select all:
     edit.select_all()
 
-
 select left:
     edit.extend_left()
 
@@ -67,6 +66,10 @@ select up:
 
 select down:
     edit.extend_line_down()
+
+select this:
+    edit.word_right()
+    edit.extend_word_left()
 
 select word left:
     edit.extend_word_left()
@@ -111,6 +114,11 @@ clear down:
     edit.extend_line_down()
     edit.delete()
 
+clear this:
+    edit.word_right()
+    edit.extend_word_left()
+    edit.delete()
+
 clear word left:
     edit.extend_word_left()
     edit.delete()
@@ -136,48 +144,73 @@ clear way down:
     edit.delete()
 
 #copy commands
-copy all: 
+copy all:
     edit.select_all()
     edit.copy()
 #to do: do we want these variants, seem to conflict
-# copy left: 
+# copy left:
 #      edit.extend_left()
 #      edit.copy()
-# copy right: 
+# copy right:
 #     edit.extend_right()
 #     edit.copy()
-# copy up: 
+# copy up:
 #     edit.extend_up()
 #     edit.copy()
-# copy down: 
+# copy down:
 #     edit.extend_down()
 #     edit.copy()
-copy word left: 
+
+copy this:
+    edit.word_right()
     edit.extend_word_left()
     edit.copy()
-copy word right: 
+
+copy word left:
+    edit.extend_word_left()
+    edit.copy()
+
+copy word right:
     edit.extend_word_right()
     edit.copy()
+
+copy line:
+    edit.line_start()
+    edit.extend_line_end()
+    edit.copy()
+
 #cut commands
-cut everything: 
+cut everything:
     edit.select_all()
     edit.cut()
 #to do: do we want these variants
-# cut left: 
+# cut left:
 #      edit.select_all()
 #      edit.cut()
-# cut right: 
+# cut right:
 #      edit.select_all()
 #      edit.cut()
-# cut up: 
+# cut up:
 #      edit.select_all()
 #     edit.cut()
-# cut down: 
+# cut down:
 #     edit.select_all()
 #     edit.cut()
-cut word left: 
+
+cut this:
+    edit.word_right()
     edit.extend_word_left()
     edit.cut()
-cut word right: 
+
+cut word left:
+    edit.extend_word_left()
+    edit.cut()
+
+cut word right:
     edit.extend_word_right()
+    edit.cut()
+
+cut line:
+    edit.line_start()
+    edit.extend_line_end()
     edit.cut()


### PR DESCRIPTION
These actions are very common in everyday use and they currently take
2 commands to perform.

 - "**(select/clear/copy/cut) this**": apply action to word on which the
                                   cursor is on (not in borders).

 - "**(copy/cut) line**": apply action to whole line.