### PR TITLE
Make use of built-in actions for generic editor functionality

### DIFF
--- a/apps/mac/edit.talon
+++ b/apps/mac/edit.talon
@@ -1,63 +1,63 @@
 os: mac
 -
-action(edit.copy): 
+action(edit.copy):
 	key(cmd-c)
- 
-action(edit.cut): 
+
+action(edit.cut):
 	key(cmd-x)
-	
-action(edit.delete): 
+
+action(edit.delete):
 	key(backspace)
-	
-action(edit.delete_line): 
+
+action(edit.delete_line):
 	edit.select_line()
 	edit.delete()
-	
-#action(edit.delete_paragraph): 
 
-#action(edit.delete_sentence): 
+#action(edit.delete_paragraph):
+
+#action(edit.delete_sentence):
 
 action(edit.delete_word):
-	actions.edit.select_word()
-	actions.edit.delete()
+	edit.select_word()
+	edit.delete()
 
-action(edit.down): 
+action(edit.down):
 	key(down)
-	
-#action(edit.extend_again): 
 
-#action(edit.extend_column): 
+#action(edit.extend_again):
+
+#action(edit.extend_column):
 
 action(edit.extend_down):
 	key(shift-down)
-	
+
 action(edit.extend_file_end):
 	key(cmd-shift-down)
-	
+
 action(edit.extend_file_start):
 	key(cmd-shift-up)
-	
+
 action(edit.extend_left):
 	key(shift-left)
-	
-#action(edit.extend_line): 
 
-action(edit.extend_line_down):       
+#action(edit.extend_line):
+
+action(edit.extend_line_down):
 	key(shift-down)
 
-action(edit.extend_line_end): 
+action(edit.extend_line_end):
 	key(cmd-shift-right)
 
-action(edit.extend_line_start): 
+action(edit.extend_line_start):
 	key(cmd-shift-left)
 
-action(edit.extend_line_up): 
+action(edit.extend_line_up):
 	key(shift-up)
-	
-action(edit.extend_page_down): 
+
+action(edit.extend_page_down):
 	key(cmd-shift-pagedown)
 
-action(edit.extend_page_up): 
+action(edit.extend_page_up):
 	key(cmd-shift-pageup)
 
 #action(edit.extend_paragraph_end):
@@ -67,7 +67,7 @@ action(edit.extend_page_up):
 
 action(edit.extend_right):
 	key(shift-right)
-	
+
 #action(edit.extend_sentence_end):
 #action(edit.extend_sentence_next):
 #action(edit.extend_sentence_previous):
@@ -75,7 +75,7 @@ action(edit.extend_right):
 
 action(edit.extend_up):
 	key(shift-up)
-	
+
 action(edit.extend_word_left):
 	key(shift-alt-left)
 
@@ -109,30 +109,30 @@ action(edit.indent_more):
 
 action(edit.left):
 	key(left)
-	
+
 action(edit.line_down):
 	key(down home)
-	
+
 action(edit.line_end):
 	key(cmd-right)
 
 action(edit.line_insert_down):
 	key(end enter)
-	
+
 action(edit.line_insert_up):
 	key(cmd-left enter up)
 
 action(edit.line_start):
 	key(cmd-left)
-	
+
 action(edit.line_up):
 	key(up cmd-left)
-	
+
 #action(edit.move_again):
 
 action(edit.page_down):
 	key(pagedown)
-	
+
 action(edit.page_up):
 	key(pageup)
 
@@ -143,28 +143,28 @@ action(edit.page_up):
 
 action(edit.paste):
 	key(cmd-v)
-	
+
 action(edit.paste_match_style):
 	key(cmd-alt-shift-v)
 
 action(edit.print):
 	key(cmd-p)
-	
+
 action(edit.redo):
 	key(cmd-shift-z)
-	
+
 action(edit.right):
 	key(right)
-	
+
 action(edit.save):
 	key(cmd-s)
 
 action(edit.save_all):
 	key(cmd-shift-s)
-	
+
 action(edit.select_all):
 	key(cmd-a)
-	
+
 action(edit.select_line):
 	key(cmd-right cmd-shift-left)
 
@@ -172,12 +172,13 @@ action(edit.select_line):
 
 action(edit.select_none):
 	key(right)
-	
+
 #action(edit.select_paragraph):
 #action(edit.select_sentence):
 
 action(edit.select_word):
-	key(left shift-right left alt-left alt-right shift-alt-left)
+	edit.word_left()
+	edit.extend_word_right()
 
 #action(edit.selected_text): -> str
 #action(edit.sentence_end):
@@ -187,7 +188,7 @@ action(edit.select_word):
 
 action(edit.undo):
 	key(cmd-z)
-	
+
 action(edit.up):
 	key(up)
 
@@ -202,7 +203,6 @@ action(edit.zoom_in):
 
 action(edit.zoom_out):
 	key(cmd--)
-	
+
 action(edit.zoom_reset):
 	key(cmd-0)
-	

--- a/apps/win/edit.talon
+++ b/apps/win/edit.talon
@@ -1,64 +1,64 @@
 os: windows
 os: linux
 -
-action(edit.copy): 
+action(edit.copy):
 	key(ctrl-c)
- 
-action(edit.cut): 
+
+action(edit.cut):
 	key(ctrl-x)
-	
-action(edit.delete): 
+
+action(edit.delete):
 	key(backspace)
-	
-action(edit.delete_line): 
+
+action(edit.delete_line):
 	edit.select_line()
 	edit.delete()
-	
-#action(edit.delete_paragraph): 
 
-#action(edit.delete_sentence): 
+#action(edit.delete_paragraph):
+
+#action(edit.delete_sentence):
 
 action(edit.delete_word):
-	actions.edit.select_word()
-	actions.edit.delete()
+	edit.select_word()
+	edit.delete()
 
-action(edit.down): 
+action(edit.down):
 	key(down)
-	
-#action(edit.extend_again): 
 
-#action(edit.extend_column): 
+#action(edit.extend_again):
+
+#action(edit.extend_column):
 
 action(edit.extend_down):
 	key(shift-down)
-	
+
 action(edit.extend_file_end):
 	key(shift-ctrl-end)
-	
+
 action(edit.extend_file_start):
 	key(shift-ctrl-home)
-	
+
 action(edit.extend_left):
 	key(shift-left)
-	
-#action(edit.extend_line): 
 
-action(edit.extend_line_down): 
+#action(edit.extend_line):
+
+action(edit.extend_line_down):
 	key(shift-down)
 
-action(edit.extend_line_end): 
+action(edit.extend_line_end):
 	key(shift-end)
 
-action(edit.extend_line_start): 
+action(edit.extend_line_start):
 	key(shift-home)
 
-action(edit.extend_line_up): 
+action(edit.extend_line_up):
 	key(shift-up)
-	
-action(edit.extend_page_down): 
+
+action(edit.extend_page_down):
 	key(shift-pagedown)
 
-action(edit.extend_page_up): 
+action(edit.extend_page_up):
 	key(shift-pageup)
 
 #action(edit.extend_paragraph_end):
@@ -68,7 +68,7 @@ action(edit.extend_page_up):
 
 action(edit.extend_right):
 	key(shift-right)
-	
+
 #action(edit.extend_sentence_end):
 #action(edit.extend_sentence_next):
 #action(edit.extend_sentence_previous):
@@ -76,7 +76,7 @@ action(edit.extend_right):
 
 action(edit.extend_up):
 	key(shift-up)
-	
+
 action(edit.extend_word_left):
 	key(ctrl-shift-left)
 
@@ -108,30 +108,30 @@ action(edit.indent_more):
 
 action(edit.left):
 	key(left)
-	
+
 action(edit.line_down):
 	key(down home)
-	
+
 action(edit.line_end):
 	key(end)
 
 action(edit.line_insert_down):
 	key(end enter)
-	
+
 action(edit.line_insert_up):
 	key(home enter up)
 
 action(edit.line_start):
 	key(home)
-	
+
 action(edit.line_up):
 	key(up home)
-	
+
 #action(edit.move_again):
 
 action(edit.page_down):
 	key(pagedown)
-	
+
 action(edit.page_up):
 	key(pageup)
 
@@ -142,27 +142,27 @@ action(edit.page_up):
 
 action(edit.paste):
 	key(ctrl-v)
-	
+
 #action(paste_match_style):
 
 action(edit.print):
 	key(ctrl-p)
-	
+
 action(edit.redo):
 	key(ctrl-y)
-	
+
 action(edit.right):
 	key(right)
-	
+
 action(edit.save):
 	key(ctrl-s)
 
 action(edit.save_all):
 	key(ctrl-shift-s)
-	
+
 action(edit.select_all):
 	key(ctrl-a)
-	
+
 action(edit.select_line):
 	key(end shift-home)
 
@@ -170,7 +170,7 @@ action(edit.select_line):
 
 action(edit.select_none):
 	key(right)
-	
+
 #action(edit.select_paragraph):
 #action(edit.select_sentence):
 
@@ -185,7 +185,7 @@ action(edit.select_word):
 
 action(edit.undo):
 	key(ctrl-z)
-	
+
 action(edit.up):
 	key(up)
 
@@ -203,4 +203,3 @@ action(edit.zoom_out):
 
 action(edit.zoom_reset):
 	key(ctrl-0)
-	

--- a/text/generic_editor.talon
+++ b/text/generic_editor.talon
@@ -49,8 +49,7 @@ go page up:
 
 # selecting
 select line:
-    edit.line_start()
-    edit.extend_line_end()
+    edit.select_line()
 
 select all:
     edit.select_all()
@@ -68,8 +67,7 @@ select down:
     edit.extend_line_down()
 
 select word:
-    edit.word_right()
-    edit.extend_word_left()
+    edit.select_word()
 
 select word left:
     edit.extend_word_left()
@@ -115,9 +113,7 @@ clear down:
     edit.delete()
 
 clear word:
-    edit.word_right()
-    edit.extend_word_left()
-    edit.delete()
+    edit.delete_word()
 
 clear word left:
     edit.extend_word_left()
@@ -162,8 +158,7 @@ copy all:
 #     edit.copy()
 
 copy word:
-    edit.word_right()
-    edit.extend_word_left()
+    edit.select_word()
     edit.copy()
 
 copy word left:
@@ -175,8 +170,7 @@ copy word right:
     edit.copy()
 
 copy line:
-    edit.line_start()
-    edit.extend_line_end()
+    edit.select_line()
     edit.copy()
 
 #cut commands
@@ -198,8 +192,7 @@ cut everything:
 #     edit.cut()
 
 cut word:
-    edit.word_right()
-    edit.extend_word_left()
+    edit.select_word()
     edit.cut()
 
 cut word left:
@@ -211,6 +204,5 @@ cut word right:
     edit.cut()
 
 cut line:
-    edit.line_start()
-    edit.extend_line_end()
+    edit.select_line()
     edit.cut()


### PR DESCRIPTION
Also:

- Fix `edit.delete_word` action in windows and mac.
- Change `edit.select_word` action in mac so that it selects the current word (it selects the previous one if the cursor is before the first letter.
